### PR TITLE
NEW FEATURE: Implement Array type for SQL types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -77,3 +77,7 @@ export function Boolean(): ReturnType<SqlType> {
 export function Decimal(precision: number, scale: number): SqlType {
   return () => `Decimal(${precision},${scale})`;
 }
+
+export function Array(type: SqlType): SqlType {
+  return () => `Array(${type()})`;
+}


### PR DESCRIPTION
This pull request adds support for array SQL types in the codebase. The main change is the introduction of a new function to generate array type definitions.

New SQL type support:

* Added an `Array` function to `src/types.ts` that takes a `SqlType` and returns a corresponding array type string, enabling easier definition of array types in SQL schemas.